### PR TITLE
CONFETI-31 refactor: 새로 만든 External 서버로 배포되도록 CI/CD 워크플로우 수정

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -102,30 +102,6 @@ jobs:
 
     # Action을 사용하여 Step을 구성
     steps:
-      # Github Action 환경의 Public IP 가져오기
-      - name: Get Github action IP
-        id: ip
-        uses: haythem/public-ip@v1.2
-
-      # AWS 인증
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_NAME }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      # AWS ECR 로그인
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: true
-
-      # 보안 규칙에 ssh IP 추가
-      - name: Add Github Actions IP to Security group
-        run: |
-          aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
-
       # 원격 서버에 배포
       - name: docker container deploy
         uses: appleboy/ssh-action@master
@@ -138,9 +114,4 @@ jobs:
             cd ~
             sudo docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
             cd server
-            ./rate-limiter-deploy.sh
-
-      # 보안 규칙에 ssh IP 삭제
-      - name: Remove Github Actions IP from security group
-        run: |
-          aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+            bash deploy-confeti-external.sh


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 새로운 External 서버의 도메인은 external.confeti.xyz 입니다.
- Apple Music 서버의 요구사항대로 SSL 설정을 했고, 내부 서버로 이용할 예정이므로 confeti-api 서버와 동일한 서브넷에 두었습니다.
- 내부 IP 대역에서만 요청이 가능하고, 외부에서 요청 시 Nginx에서 403 Forbidden을 응답하도록 설정했습니다.
- 자세한 접속 정보는 내부 문서로 전달드리겠습니다.

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
