### PR TITLE
CONFETI-75 feat: TopSong 목록 조회 API에 offset 쿼리스트링 추가

### DIFF
--- a/src/main/java/confeti/confetiratelimiter/api/applemusic/controller/AppleMusicController.java
+++ b/src/main/java/confeti/confetiratelimiter/api/applemusic/controller/AppleMusicController.java
@@ -4,6 +4,7 @@ import confeti.confetiratelimiter.api.applemusic.facade.AppleMusicFacade;
 import confeti.confetiratelimiter.domain.applemusic.application.AppleMusicValidateService;
 import confeti.confetiratelimiter.domain.applemusic.common.AppleMusicFetchLimit;
 import confeti.confetiratelimiter.global.common.response.ApiResponseUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,9 +50,10 @@ public class AppleMusicController {
     @GetMapping("/artists/{id}/view/top-songs")
     public Mono<ResponseEntity<?>> getArtistTopSongsById(
             @PathVariable String id,
-            @RequestParam String limit
+            @RequestParam String limit,
+            @RequestParam(required = false) String offset
     ) {
-        return appleMusicFacade.getArtistTopSongsById(id, limit)
+        return appleMusicFacade.getArtistTopSongsById(id, limit, offset)
                 .map(ApiResponseUtil::success);
     }
 

--- a/src/main/java/confeti/confetiratelimiter/api/applemusic/facade/AppleMusicFacade.java
+++ b/src/main/java/confeti/confetiratelimiter/api/applemusic/facade/AppleMusicFacade.java
@@ -44,8 +44,8 @@ public class AppleMusicFacade {
         return appleMusicService.getRelatedArtistsById(id, limit);
     }
 
-    public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit) {
-        return appleMusicService.getArtistTopSongsById(id, limit);
+    public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit, String offset) {
+        return appleMusicService.getArtistTopSongsById(id, limit, offset);
     }
 
 

--- a/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
+++ b/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
@@ -46,9 +46,9 @@ public class AppleMusicService {
         return client.getRelatedArtistsById(id, limit);
     }
 
-    public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit) {
+    public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit, String offset) {
         log.info("AppleMusicService.getArtistTopSongsById Artist top songs lookup started. Target artist IDs : {}, View : top-songs, Limit : {}", id, limit);
-        return client.getArtistTopSongsById(id, limit);
+        return client.getArtistTopSongsById(id, limit, offset);
     }
 
     public Mono<AppleMusicArtistSongsResponse> getArtistMusicsById(String id, String limit, String offset) {

--- a/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
+++ b/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
@@ -47,7 +47,7 @@ public class AppleMusicService {
     }
 
     public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit, String offset) {
-        log.info("AppleMusicService.getArtistTopSongsById Artist top songs lookup started. Target artist IDs : {}, View : top-songs, Limit : {}", id, limit);
+        log.info("AppleMusicService.getArtistTopSongsById Artist top songs lookup started. Target artist IDs : {}, View : top-songs, Limit : {}, Offset : {}", id, limit, offset);
         return client.getArtistTopSongsById(id, limit, offset);
     }
 

--- a/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
+++ b/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
@@ -46,7 +46,8 @@ public interface AppleMusicFeignClient {
     @GetMapping("/artists/{id}/view/top-songs")
     Mono<AppleMusicSongsResponse> getArtistTopSongsById(
             @PathVariable String id,
-            @RequestParam String limit
+            @RequestParam String limit,
+            @RequestParam String offset
     );
 
     /**

--- a/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
+++ b/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
@@ -47,7 +47,7 @@ public interface AppleMusicFeignClient {
     Mono<AppleMusicSongsResponse> getArtistTopSongsById(
             @PathVariable String id,
             @RequestParam String limit,
-            @RequestParam String offset
+            @RequestParam(required = false) String offset
     );
 
     /**


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
-  TopSong 목록 조회 API에 offset 파라미터 추가
  - SongBatch 작업 시 기존 Song 목록 조회 API의 limit이 20이어서 TopSong 목록 조회 API를 사용함. 그런데 기존 TopSong 조회 API는 offset이 없어서 모든 노래 조회가 불가능했음. 따라서 offset 파라미터를 쿼리스트링으로 추가함
  - 기존에 해당 API를 사용하던 부분에 영향을 미치지 않도록 required=false로 둠

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
