### PR TITLE
CONFETI-76 feat: Similar Artist 목록 조회 API 에 offset 쿼리스트링 추가

### DIFF
--- a/src/main/java/confeti/confetiratelimiter/api/applemusic/controller/AppleMusicController.java
+++ b/src/main/java/confeti/confetiratelimiter/api/applemusic/controller/AppleMusicController.java
@@ -41,9 +41,10 @@ public class AppleMusicController {
     @GetMapping("/artists/{id}/view/similar-artists")
     public Mono<ResponseEntity<?>> getRelatedArtistsById(
             @PathVariable String id,
-            @RequestParam String limit
+            @RequestParam String limit,
+            @RequestParam(required = false) String offset
     ) {
-        return appleMusicFacade.getRelatedArtistsById(id, limit)
+        return appleMusicFacade.getRelatedArtistsById(id, limit, offset)
                 .map(ApiResponseUtil::success);
     }
 

--- a/src/main/java/confeti/confetiratelimiter/api/applemusic/facade/AppleMusicFacade.java
+++ b/src/main/java/confeti/confetiratelimiter/api/applemusic/facade/AppleMusicFacade.java
@@ -40,8 +40,8 @@ public class AppleMusicFacade {
                 .map(AppleMusicArtistsResponse::new);
     }
 
-    public Mono<AppleMusicArtistsResponse> getRelatedArtistsById(String id, String limit) {
-        return appleMusicService.getRelatedArtistsById(id, limit);
+    public Mono<AppleMusicArtistsResponse> getRelatedArtistsById(String id, String limit, String offset) {
+        return appleMusicService.getRelatedArtistsById(id, limit, offset);
     }
 
     public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit, String offset) {

--- a/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
+++ b/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
@@ -42,7 +42,7 @@ public class AppleMusicService {
     }
 
     public Mono<AppleMusicArtistsResponse> getRelatedArtistsById(String id, String limit, String offset) {
-        log.info("AppleMusicService.getRelatedArtistsById Related artists lookup started. Target artist IDs : {}, View : similar-artist, Limit : {}", id, limit);
+        log.info("AppleMusicService.getRelatedArtistsById Related artists lookup started. Target artist IDs : {}, View : similar-artist, Limit : {}, Offset : {}", id, limit, offset);
         return client.getRelatedArtistsById(id, limit, offset);
     }
 

--- a/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
+++ b/src/main/java/confeti/confetiratelimiter/domain/applemusic/application/AppleMusicService.java
@@ -41,9 +41,9 @@ public class AppleMusicService {
         return client.getArtistsByIds(ids);
     }
 
-    public Mono<AppleMusicArtistsResponse> getRelatedArtistsById(String id, String limit) {
+    public Mono<AppleMusicArtistsResponse> getRelatedArtistsById(String id, String limit, String offset) {
         log.info("AppleMusicService.getRelatedArtistsById Related artists lookup started. Target artist IDs : {}, View : similar-artist, Limit : {}", id, limit);
-        return client.getRelatedArtistsById(id, limit);
+        return client.getRelatedArtistsById(id, limit, offset);
     }
 
     public Mono<AppleMusicSongsResponse> getArtistTopSongsById(String id, String limit, String offset) {

--- a/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
+++ b/src/main/java/confeti/confetiratelimiter/external/client/AppleMusicFeignClient.java
@@ -56,8 +56,9 @@ public interface AppleMusicFeignClient {
      */
     @GetMapping("/artists/{id}/view/similar-artists")
     Mono<AppleMusicArtistsResponse> getRelatedArtistsById(
-            @PathVariable String id,
-            @RequestParam String limit
+        @PathVariable String id,
+        @RequestParam String limit,
+        @RequestParam(required = false) String offset
     );
 
     /**

--- a/src/main/java/confeti/confetiratelimiter/external/client/dto/response/artist/AppleMusicArtistsResponse.java
+++ b/src/main/java/confeti/confetiratelimiter/external/client/dto/response/artist/AppleMusicArtistsResponse.java
@@ -3,6 +3,10 @@ package confeti.confetiratelimiter.external.client.dto.response.artist;
 import java.util.List;
 
 public record AppleMusicArtistsResponse(
+        String next,
         List<AppleMusicArtistResponse> data
 ) {
+    public AppleMusicArtistsResponse(List<AppleMusicArtistResponse> data){
+        this(null, data);
+    }
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- Similar Artist 목록 조회 API 에 offset 쿼리스트링 추가
- AppleMusicArtistsResponse 에 next 필드 추가
  - 기존에는 Artist 목록 조회 시 next 를 사용하는 케이스가 없었는데 batch 작업 시 존재하는 모든 relatedArtist 를 가져와서 정합성을 맞춰주고 있으므로 offset과 next 필드가 필요하게 됨

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
